### PR TITLE
Pull total count for cumulative calculation instead of filtering with…

### DIFF
--- a/webapp.js
+++ b/webapp.js
@@ -261,7 +261,6 @@ function getTotalBefore(date, dailyData, res, userId, category) {
   db.collection(config.mongoCollection).aggregate([
     {$match: {
       $and: [
-        {'date': {$lt: date}},
         {'userId': userId},
         {'category': category}
       ]
@@ -318,8 +317,12 @@ function formatDailyInput(aggregatedDailyData, datesInput) {
 };
 
 function formatCumulativeInput(daily, remaining) {
-  var remainingCount = remaining[0] ? remaining[0].count : 0;
+  var totalCount = remaining[0] ? remaining[0].count : 0;
   var countsCopy = daily.slice();
+  var dailyCount = countsCopy.reduce(function(acc, item) {
+    return Number.isInteger(item) ? item : 0;
+  }, 0);
+  var remainingCount = totalCount - dailyCount;
 
   for (var i = 2; i < countsCopy.length; i++) {
     countsCopy[i] = countsCopy[i] + countsCopy[i - 1];


### PR DESCRIPTION
… date

Filter using less than (le) in mongodb wasn't including days that were
not included in daily count query. Removed filter to pull count
for all time. Then subtract the counts we include in the daily charts.