### PR TITLE
Fix charting issue new year

### DIFF
--- a/app_modules/c3Helper.js
+++ b/app_modules/c3Helper.js
@@ -15,9 +15,10 @@ function createDateLabels() {
   var dateObj = new Date();
 
   for (i = 0; i < 6; i++) {
+    var year = dateObj.getFullYear() - 2000;
     var month = dateObj.getMonth() + 1;
     var date = dateObj.getDate() ;
-    var label =  month + '-' + date;
+    var label = `${month}-${date}-${year}`;
     dates.unshift(label);
     dateObj.setDate(dateObj.getDate() - 1);
   };
@@ -28,7 +29,8 @@ function createDateLabels() {
 function formatDaily(aggregatedDailyData, datesInput) {
   var dataDict = aggregatedDailyData.reduce(
     function(d, item) {
-      d[item._id] = item.count;
+      var dateLabel = `${item._id.monthDay}-${item._id.year-2000}`
+      d[dateLabel] = item.count;
       return d;
     }, {}
   );

--- a/app_modules/c3Helper.js
+++ b/app_modules/c3Helper.js
@@ -15,7 +15,7 @@ function createDateLabels() {
   var dateObj = new Date();
 
   for (i = 0; i < 6; i++) {
-    var year = dateObj.getFullYear() - 2000;
+    var year = dateObj.getFullYear();
     var month = dateObj.getMonth() + 1;
     var date = dateObj.getDate() ;
     var label = `${month}-${date}-${year}`;
@@ -29,7 +29,7 @@ function createDateLabels() {
 function formatDaily(aggregatedDailyData, datesInput) {
   var dataDict = aggregatedDailyData.reduce(
     function(d, item) {
-      var dateLabel = `${item._id.monthDay}-${item._id.year-2000}`
+      var dateLabel = `${item._id.monthDay}-${item._id.year}`
       d[dateLabel] = item.count;
       return d;
     }, {}

--- a/app_modules/dataManager.js
+++ b/app_modules/dataManager.js
@@ -48,7 +48,10 @@ function getDailyandTotalData(date, res, userId, category, db) {
       ]
     }},
     {$group: {
-      _id: '$monthDay',
+      _id: {
+        "monthDay": "$monthDay",
+        "year": {$year: "$date"}
+      },
       count: {$sum: '$amount'}
     }}
   ], function(err, data) {

--- a/src/components/ChartInstance.js
+++ b/src/components/ChartInstance.js
@@ -24,7 +24,7 @@ var ChartInstance = React.createClass({
   formatData: function() {
     var chartData = {
       x: 'x',
-      xFormat: '%m-%d-%y',
+      xFormat: '%m-%d-%Y',
       columns: [this.props.dates, this.props.data],
       types: {
         daily: 'bar'

--- a/src/components/ChartInstance.js
+++ b/src/components/ChartInstance.js
@@ -11,7 +11,7 @@ var ChartInstance = React.createClass({
           type: 'timeseries',
           localtime: false,
           tick: {
-            format: '%m-%d'
+            format: '%m-%d-%y'
           }
         }
       },
@@ -24,7 +24,7 @@ var ChartInstance = React.createClass({
   formatData: function() {
     var chartData = {
       x: 'x',
-      xFormat: '%m-%d',
+      xFormat: '%m-%d-%y',
       columns: [this.props.dates, this.props.data],
       types: {
         daily: 'bar'


### PR DESCRIPTION
C3 charts were using '%m-%d' format. Charting library assumed January entries created in new year were part of previous year, resulting in weird formatting. Added the yearly portion to the dates.